### PR TITLE
Use octokit's auto pagination

### DIFF
--- a/lib/github-release.rb
+++ b/lib/github-release.rb
@@ -16,9 +16,7 @@ class GithubRelease
 
 	private
 	def api
-		@api ||= Octokit::Client.new(:access_token => token)
-		@api.auto_paginate = true
-		@api
+		@api ||= Octokit::Client.new(:access_token => token, :auto_paginate => true)
 	end
 
 	def token

--- a/lib/github-release.rb
+++ b/lib/github-release.rb
@@ -17,6 +17,8 @@ class GithubRelease
 	private
 	def api
 		@api ||= Octokit::Client.new(:access_token => token)
+		@api.auto_paginate = true
+		@api
 	end
 
 	def token
@@ -91,18 +93,8 @@ class GithubRelease
 	end
 
 	def github_releases
-		@github_releases ||= api_repo_rels[:releases].get.data.map(&:tag_name)
+		@github_releases ||= api.releases(repo_name).map(&:tag_name)
 		log_val(@github_releases)
-	end
-
-	def api_repo
-		@api_repo ||= api.repo(repo_name)
-		log_val(@api_repo)
-	end
-
-	def api_repo_rels
-		@api_repo_rels ||= api_repo.rels
-		log_val(@api_repo_rels)
 	end
 
 	def git_config(item, default = nil)


### PR DESCRIPTION
Increases the limit on the amount of releases returned to be compared against local tags. 
Without this change, only the most recent 30 releases are listed. If local release/tag number is higher than this, then github-release attempts to re-release an older version, which fails since it already exists. 

https://github.com/octokit/octokit.rb#auto-pagination
